### PR TITLE
Add support for loading existing alt mode files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 Deps/
 obj/
 lib/
+.vs

--- a/AlternativeGameModes/AlternativeGameModes.cs
+++ b/AlternativeGameModes/AlternativeGameModes.cs
@@ -5,6 +5,11 @@ namespace DDoor.AlternativeGameModes;
 
 public static class AlternativeGameModes
 {
+	public static void Add(string name, System.Action effect)
+	{
+		modes.Add(new() { Name = name, Effect = effect });
+	}
+
 	public static void Add(string name, System.Action effect, string modeKey)
 	{
 		modes.Add(new() { Name = name, Effect = effect, ModeKey = modeKey });
@@ -108,6 +113,12 @@ public static class AlternativeGameModes
 				// Start at index of 1 to skip the default "START" mode
 				for (int i = 1; i < modes.Count; i++)
 				{
+					// Skip modes that don't specify a mode key
+					if (string.IsNullOrEmpty(modes[i].ModeKey))
+					{
+						continue;
+					}
+
 					if (__instance.saveFile.IsKeyUnlocked(modes[i].ModeKey))
 					{
 						modes[i].Effect();

--- a/AlternativeGameModes/AlternativeGameModes.cs
+++ b/AlternativeGameModes/AlternativeGameModes.cs
@@ -5,98 +5,116 @@ namespace DDoor.AlternativeGameModes;
 
 public static class AlternativeGameModes
 {
-    public static void Add(string name, System.Action effect)
-    {
-        modes.Add(new() { Name = name, Effect = effect });
-    }
+	public static void Add(string name, System.Action effect, string modeKey)
+	{
+		modes.Add(new() { Name = name, Effect = effect, ModeKey = modeKey });
+	}
 
-    public static string SelectedModeName => modes[selectedMode].Name;
+	public static string SelectedModeName => modes[selectedMode].Name;
 
-    private struct AltGameMode
-    {
-        internal string Name;
-        internal System.Action Effect;
-    }
+	private struct AltGameMode
+	{
+		internal string Name;
+		internal System.Action Effect;
+		internal string ModeKey;
+	}
 
-    private static readonly Collections.List<AltGameMode> modes = new()
-    {
-        new() {Name = "START", Effect = () => {}}
-    };
+	private static readonly Collections.List<AltGameMode> modes = new()
+	{
+		new() {Name = "START", Effect = () => {}}
+	};
 
-    private static int selectedMode = 0;
+	private static int selectedMode = 0;
 
-    [HL.HarmonyPatch(typeof(SaveMenu), nameof(SaveMenu.closeSubMenu))]
-    private static class CloseSubMenuPatch
-    {
-        private static void Postfix(SaveMenu __instance, bool silent)
-        {
-            // When silent = true, we are starting the game.
-            // We need to keep the mode set until NewGamePatch runs.
-            if (!silent)
-            {
-                selectedMode = 0;
-                __instance.selectedOptions[0].buttonText.text = modes[selectedMode].Name;
-            }
-        }
-    }
+	[HL.HarmonyPatch(typeof(SaveMenu), nameof(SaveMenu.closeSubMenu))]
+	private static class CloseSubMenuPatch
+	{
+		private static void Postfix(SaveMenu __instance, bool silent)
+		{
+			// When silent = true, we are starting the game.
+			// We need to keep the mode set until NewGamePatch runs.
+			if (!silent)
+			{
+				selectedMode = 0;
+				__instance.selectedOptions[0].buttonText.text = modes[selectedMode].Name;
+			}
+		}
+	}
 
-    // SaveMenu does not have any implementation for onLeftEvent
-    // or onRightEvent, so we cannot hook that directly.
-    // Instead, we hook on UIObject and check if we're operating on
-    // the SaveMenu. It's suboptimal but it works.
-    [HL.HarmonyPatch(typeof(UIObject), nameof(UIObject.onRightEvent))]
-    private static class RightPatch
-    {
-        private static void Postfix(UIObject __instance)
-        {
-            if (!(__instance is SaveMenu sm))
-            {
-                return;
-            }
-            if (sm.selectedSlot && sm.optionIndex == 0)
-            {
-                selectedMode = (selectedMode + 1) % modes.Count;
-                sm.selectedOptions[0].buttonText.text = modes[selectedMode].Name;
-            }
-        }
-    }
+	// SaveMenu does not have any implementation for onLeftEvent
+	// or onRightEvent, so we cannot hook that directly.
+	// Instead, we hook on UIObject and check if we're operating on
+	// the SaveMenu. It's suboptimal but it works.
+	[HL.HarmonyPatch(typeof(UIObject), nameof(UIObject.onRightEvent))]
+	private static class RightPatch
+	{
+		private static void Postfix(UIObject __instance)
+		{
+			if (!(__instance is SaveMenu sm))
+			{
+				return;
+			}
+			if (sm.selectedSlot && sm.optionIndex == 0)
+			{
+				selectedMode = (selectedMode + 1) % modes.Count;
+				sm.selectedOptions[0].buttonText.text = modes[selectedMode].Name;
+			}
+		}
+	}
 
-    [HL.HarmonyPatch(typeof(UIObject), nameof(UIObject.onLeftEvent))]
-    private static class LeftPatch
-    {
-        private static void Postfix(UIObject __instance)
-        {
-            if (!(__instance is SaveMenu sm))
-            {
-                return;
-            }
-            if (sm.selectedSlot && sm.optionIndex == 0)
-            {
-                selectedMode--;
-                if (selectedMode < 0)
-                {
-                    selectedMode += modes.Count;
-                }
-                sm.selectedOptions[0].buttonText.text = modes[selectedMode].Name;
-            }
-        }
-    }
+	[HL.HarmonyPatch(typeof(UIObject), nameof(UIObject.onLeftEvent))]
+	private static class LeftPatch
+	{
+		private static void Postfix(UIObject __instance)
+		{
+			if (!(__instance is SaveMenu sm))
+			{
+				return;
+			}
+			if (sm.selectedSlot && sm.optionIndex == 0)
+			{
+				selectedMode--;
+				if (selectedMode < 0)
+				{
+					selectedMode += modes.Count;
+				}
+				sm.selectedOptions[0].buttonText.text = modes[selectedMode].Name;
+			}
+		}
+	}
 
-    [HL.HarmonyPatch(typeof(SaveSlot), nameof(SaveSlot.useSaveFile))]
-    private static class NewGamePatch
-    {
-        private static void Prefix(SaveSlot __instance)
-        {
-            if (!__instance.saveFile.IsLoaded())
-            {
-                // The original code does this anyway at the very start
-                // of useSaveFile. We do it here, slightly sooner,
-                // so that the Effect has access to the save file the 
-                // same way as in normal code.
-                GameSave.currentSave = __instance.saveFile;
-                modes[selectedMode].Effect();
-                selectedMode = 0;
-            }
-        }
-    }
+	[HL.HarmonyPatch(typeof(SaveSlot), nameof(SaveSlot.useSaveFile))]
+	private static class NewGamePatch
+	{
+		private static void Prefix(SaveSlot __instance)
+		{
+			// The original code does this anyway at the very start
+			// of useSaveFile. We do it here, slightly sooner,
+			// so that the Effect has access to the save file the 
+			// same way as in normal code.
+			GameSave.currentSave = __instance.saveFile;
+
+			// If creating new file
+			if (!__instance.saveFile.IsLoaded())
+			{
+				modes[selectedMode].Effect();
+				selectedMode = 0;
+			}
+			// If loading an existing file
+			else
+			{
+				// Check if file is an alt game mode
+				// If it is, run its delegate
+				// Start at index of 1 to skip the default "START" mode
+				for (int i = 1; i < modes.Count; i++)
+				{
+					if (__instance.saveFile.IsKeyUnlocked(modes[i].ModeKey))
+					{
+						modes[i].Effect();
+						break;
+					}
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
I noticed alt game modes could only run their effect delegate at file creation time. This adds support for invoking the effect delegate on loading older files, even across game sessions.

**Changes:**
- Added a `ModeKey` property to the `AltGameMode` struct. This stores the mode's save file key
- Added an `Add()` overload that takes in the `modeKey` as a parameter. This was done to avoid breaking older mods that use this, as changing the method signature would prevent them from working. `modeKey` is essentially treated as an optional parameter, as without it, it'll use the original `Add()`.

**How it works:**
When a file is loaded, it loops through the added modes and checks if the save file has the `ModeKey`. If it does, it invokes the effect.

**For mod authors:**
The `ModeKey` is the key you save to save file to mark it as a file for your game mode

**Why did I want this?**
I'm making an Archipelago implementation of the existing randomizer mod, and it's a requirement to be able to continue the file across sessions. Also, this is a nice quality of life.

I saw in the randomizer mod that you can load a mode file with ItemChanger, like so:
```cs
ItemChanger.SaveData.OnTrackerLogUpdate += log =>
{
	if (log != null && GameSave.GetSaveData().IsKeyUnlocked("ArchipelagoRandomizer"))
	{
		StartGame();
	}
};
```
But that still doesn't persist across game sessions, so if you quit the game, you lose your file essentially.

Now, all you need to do to handle activating a mode, whether from file creation, file loading, or file loading after a new session, is to do:
```cs
// "ArchipelagoRandomizer" is the optional modeKey
AGM.AlternativeGameModes.Add("ARCHIPELAGO", StartGame, "ArchipelagoRandomizer");
```